### PR TITLE
SADEV-2561: Add macOS notes and fix exercise instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To save time downloading tools during the workshop, participants should have the
 
 ### Python virtual environment
 
-To run the Python scripts in this repository, it is recommended to use a virtual environment:
+To run the Python scripts in this repository, it is recommended to use a virtual environment. Run the following from the `tools` directory:
 ```sh
 	python3 -m venv venv
 	source venv/bin/activate

--- a/exercises/attest/README.md
+++ b/exercises/attest/README.md
@@ -88,8 +88,8 @@ We are using a Python tool to verify the attestation against FIDO metadata.
 cd ../../tools
 python3 -m venv venv
 source venv/bin/activate
-pip install requests fido2 PyYAML
-cd ../../exercises/attest
+pip install fido2 requests PyYAML
+cd ../exercises/attest
 ```
 
 Note: before running the Python script, inspect its contents to get an idea of what it is doing.

--- a/exercises/keys/Dockerfile
+++ b/exercises/keys/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 RUN apt-get update && apt-get install -y openssh-server
-RUN mkdir /var/run/sshd
+RUN mkdir -p /var/run/sshd
 RUN echo "PasswordAuthentication no" >> /etc/ssh/sshd_config
 EXPOSE 22
 COPY --chown=ubuntu id_ecdsa_sk.pub /home/ubuntu/.ssh/authorized_keys

--- a/exercises/keys/README.md
+++ b/exercises/keys/README.md
@@ -6,6 +6,8 @@ Run all commands in this exercise from the `exercises/keys` directory.
 
 > **Tip:** Copy your device path from this output. You will use it for every `fido2-token` command in this exercise.
 
+> **macOS note:** The device path shown by `fido2-token -L` on macOS looks like `ioreg:n`. Use it without the trailing colon in subsequent commands (e.g. `ioreg:n` not `ioreg:n:`).
+
 - Use `fido2-token -I <device>` to get information on your security key
 
   - Check `options:` to see if a PIN is set (`clientPin`) or not (`noclientPin`)
@@ -37,6 +39,8 @@ The `credProtect` extension is required by OpenSSH if you want to enforce user v
 ssh-keygen -t ecdsa-sk -f ./id_ecdsa_sk -N ''
 ```
 
+> **macOS note:** If this fails with "no FIDO security provider", you are using the system OpenSSH instead of the Homebrew version. Run `brew install openssh` and follow the instructions in the main [README](../../README.md) to update your PATH.
+
 This `ssh-keygen` command would work from any directory, and the `-f` flag saves the files relative to wherever you currently are. For this exercise, keep running commands from `exercises/keys` so the later relative paths continue to work. Regular SSH keys normally go in `~/.ssh/`, but with FIDO keys it doesn't matter because the private key is on the security key, not in the file.
 
 Note that a passphrase is not used here. The private key is stored on the security key, not in the private key file, so there is nothing that needs encryption.
@@ -45,6 +49,18 @@ can sign in on any server that trusts the public key.
 We will see [later](#user-verification) that there is a better way to prevent this from happening.
 
 - Using your Python virtual environment, run the script in the `tools` directory to inspect the private key file:
+
+If you haven't set up the Python virtual environment yet:
+
+```sh
+cd ../../tools
+python3 -m venv venv
+source venv/bin/activate
+pip install requests fido2 PyYAML
+cd ../../exercises/keys
+```
+
+Then run the script:
 
 ```sh
 ../../tools/openssh-key-v1.py ./id_ecdsa_sk
@@ -56,7 +72,7 @@ Notice that the private key file only contains a handle to the private key gener
 ```sh
 docker build --build-arg user=ubuntu -t ssh-server .
 ```
-The Dockerfile uses Ubuntu as a base image, installs OpenSSH, disables password authentication, copies the user's public key into their `.ssh/authorized_keys` file and starts the SSH server.
+The Dockerfile uses Ubuntu as a base image, installs OpenSSH, disables password authentication, copies the user's public key into their `.ssh/authorized_keys` file and starts the SSH server. This means you need to rebuild the image every time you generate a new key, since the public key is baked in at build time.
 
 - Run the docker container:
 
@@ -73,6 +89,8 @@ ssh -i ./id_ecdsa_sk ubuntu@localhost
 ```
 
 Your security key will flash. Touch it to confirm user presence and complete the sign-in.
+
+The first time you connect, SSH will ask you to confirm the server's fingerprint. Type `yes` to continue. SSH remembers this server in your `known_hosts` file so it won't ask again on subsequent connections.
 
 The server will allow you to sign in using your hardware-backed SSH key,
 because the corresponding public key was copied into the user's `~/.ssh/authorized_keys` file
@@ -135,6 +153,8 @@ If you are prompted that a resident key already exists, you can overwrite it. If
 - Use `fido2-token -L -r <device>` to see if your new key is stored on your security key.
 
 The columns represent an index, the SHA256 hash of your RP ID, and the RP ID itself, which defaults to `ssh:`
+
+Note: your new SSH key should appear under the `ssh:` RP ID. You may also see other entries from FIDO credentials registered on websites.
 
 - Rebuild your server and verify you can still sign in:
 
@@ -206,6 +226,8 @@ ssh-keygen -K
 ```
 
 Note that all files have been regenerated, but to prevent files from overwriting one another, the file names follow a naming convention that includes the options used to create them. Use the filenames from the output for subsequent commands.
+
+Note: `ssh-keygen -K` exports all resident keys from your security key, not just the ones created in this exercise. You can ignore any extra files that don't belong to this workshop.
 
 - Verify that you can still authenticate to GitHub using the regenerated key files:
 

--- a/exercises/keys/README.md
+++ b/exercises/keys/README.md
@@ -6,7 +6,7 @@ Run all commands in this exercise from the `exercises/keys` directory.
 
 > **Tip:** Copy your device path from this output. You will use it for every `fido2-token` command in this exercise.
 
-> **macOS note:** The device path shown by `fido2-token -L` on macOS looks like `ioreg:n`. Use it without the trailing colon in subsequent commands (e.g. `ioreg:n` not `ioreg:n:`).
+> **macOS note:** The device path shown by `fido2-token -L` on macOS looks like `ioreg:n:`. Use it without the trailing colon in subsequent commands (e.g. `ioreg:n` not `ioreg:n:`).
 
 - Use `fido2-token -I <device>` to get information on your security key
 
@@ -39,7 +39,12 @@ The `credProtect` extension is required by OpenSSH if you want to enforce user v
 ssh-keygen -t ecdsa-sk -f ./id_ecdsa_sk -N ''
 ```
 
-> **macOS note:** If this fails with "no FIDO security provider", you are using the system OpenSSH instead of the Homebrew version. Run `brew install openssh` and follow the instructions in the main [README](../../README.md) to update your PATH.
+> **macOS note:** If this fails with "no FIDO security provider", install Homebrew OpenSSH with `brew install openssh`, then run `which ssh-keygen` to confirm it points to the Homebrew version. If it still shows `/usr/bin/ssh-keygen`, update your PATH:
+>
+> ```sh
+> echo 'export PATH="$(brew --prefix)/bin:$PATH"' >> ~/.zshrc
+> source ~/.zshrc
+> ```
 
 This `ssh-keygen` command would work from any directory, and the `-f` flag saves the files relative to wherever you currently are. For this exercise, keep running commands from `exercises/keys` so the later relative paths continue to work. Regular SSH keys normally go in `~/.ssh/`, but with FIDO keys it doesn't matter because the private key is on the security key, not in the file.
 
@@ -56,8 +61,8 @@ If you haven't set up the Python virtual environment yet:
 cd ../../tools
 python3 -m venv venv
 source venv/bin/activate
-pip install requests fido2 PyYAML
-cd ../../exercises/keys
+pip install fido2 requests PyYAML
+cd ../exercises/keys
 ```
 
 Then run the script:

--- a/exercises/keys/README.md
+++ b/exercises/keys/README.md
@@ -39,7 +39,12 @@ The `credProtect` extension is required by OpenSSH if you want to enforce user v
 ssh-keygen -t ecdsa-sk -f ./id_ecdsa_sk -N ''
 ```
 
-> **macOS note:** If this fails with "no FIDO security provider", you are using the system OpenSSH instead of the Homebrew version. Run `brew install openssh` and follow the instructions in the main [README](../../README.md) to update your PATH.
+> **macOS note:** If this fails with "no FIDO security provider", install Homebrew OpenSSH with `brew install openssh`, then run `which ssh-keygen` to confirm it points to the Homebrew version. If it still shows `/usr/bin/ssh-keygen`, update your PATH:
+>
+> ```sh
+> echo 'export PATH="$(brew --prefix)/bin:$PATH"' >> ~/.zshrc
+> source ~/.zshrc
+> ```
 
 This `ssh-keygen` command would work from any directory, and the `-f` flag saves the files relative to wherever you currently are. For this exercise, keep running commands from `exercises/keys` so the later relative paths continue to work. Regular SSH keys normally go in `~/.ssh/`, but with FIDO keys it doesn't matter because the private key is on the security key, not in the file.
 
@@ -56,8 +61,8 @@ If you haven't set up the Python virtual environment yet:
 cd ../../tools
 python3 -m venv venv
 source venv/bin/activate
-pip install requests fido2 PyYAML
-cd ../../exercises/keys
+pip install fido2 requests PyYAML
+cd ../exercises/keys
 ```
 
 Then run the script:

--- a/exercises/sign/Dockerfile
+++ b/exercises/sign/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 RUN apt-get update && apt-get install -y openssh-server git
-RUN mkdir /var/run/sshd
+RUN mkdir -p /var/run/sshd
 RUN echo "PasswordAuthentication no" >> /etc/ssh/sshd_config
 EXPOSE 22
 COPY --chown=ubuntu id_ecdsa_sk.pub /home/ubuntu/.ssh/authorized_keys

--- a/exercises/sign/README.md
+++ b/exercises/sign/README.md
@@ -39,7 +39,7 @@ ssh-keygen -Y verify -f ./allowed_signers -I johndoe@example.org -n test -s mess
 
 SSH signatures can also be used with Git: Both commits and tags can be signed.
 
-- Instead of using `.git`, use a separate git directory to prevent conflicts with this script's own git repository.
+- Instead of using `.git`, use a separate git directory to prevent conflicts with the workshop repository.
 
 ```
 export GIT_DIR=dotgit
@@ -85,7 +85,7 @@ git add README
 - Commit:
 
 ```
-git commit -m 'unsigned commit' README
+git commit -m 'unsigned commit'
 ```
 
 - Check the commit log:
@@ -179,7 +179,7 @@ If you have time, you can also push your signed commits to a local SSH server us
 
 Generate a separate authentication key (best practice: don't reuse your signing key for auth):
 ```
-ssh-keygen -t ecdsa-sk -f ./id_ecdsa_sk -C 'authentication key'
+ssh-keygen -t ecdsa-sk -f ./id_ecdsa_sk -C 'authentication key' -N ''
 ```
 
 Build and run the SSH server:
@@ -219,13 +219,30 @@ export GIT_SSH_COMMAND="ssh -F ./sshconfig"
 git push --set-upstream origin main
 ```
 
+- Verify that your signed commits made it to the server by exec-ing into the container:
+
+```
+docker exec -it -u ubuntu ssh_demo bash
+cd ~/scratch.git
+git log --oneline --show-signature
+```
+
+Note that the signatures will show as unverified because the server doesn't have an `allowedSignersFile` configured. To confirm the signature data is actually there, inspect the raw commit object:
+
+```
+git cat-file -p HEAD
+```
+
+You should see a `gpgsig` block containing the SSH signature. This shows that signatures are embedded in the commits themselves and travel with them when pushed to a remote.
+
+Type `exit` to leave the container.
 
 # Clean up
 
 The `GIT_DIR`, `GIT_CONFIG_GLOBAL`, and `GIT_CONFIG_SYSTEM` exports are scoped to your terminal session. Close the terminal or unset them to restore your normal git config:
 
 ```
-unset GIT_DIR GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM
+unset GIT_DIR GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_SSH_COMMAND
 ```
 
 Then remove the exercise files:


### PR DESCRIPTION
- Add macOS-specific notes for device path, OpenSSH FIDO provider, and PATH setup
- Fix Dockerfile mkdir to use -p flag for compatibility with newer Ubuntu images
- Add inline Python venv setup instructions to keys exercise
- Add known_hosts first-connection explanation
- Add note about Docker image rebuild when regenerating keys
- Add resident key RP ID explanation and fix credential delete instructions
- Add ssh-keygen -K exports all keys note
- Add note to run Python venv setup from tools directory in main README

- Tested exercises (keys, signing, attestation) end to end on macOS (M1 Pro)
- Previously tested on Windows with Git Bash